### PR TITLE
Return skill name on trap synergies

### DIFF
--- a/d2planner/src/formatters.js
+++ b/d2planner/src/formatters.js
@@ -291,7 +291,7 @@ function createFillTaWithCalcAFormatter (pattern) {
 function createFillTbWithCalcAFormatter (pattern) {
   function formatter (skill, lvl, skillLevels, skillBonuses, difficulty, ta, tb, ca, cb) {
     const calcA = calculateSkillValue(ca, skill, lvl, skillLevels, skillBonuses);
-    return tb.replace(pattern, calcA);
+    return `${ta}: ${tb.replace(pattern, calcA)}`;
   }
   return formatter;
 }


### PR DESCRIPTION
Formatter was incorrectly written to only return the text b, so the skill names were missing from some trap synergies.